### PR TITLE
Fix bug in percentage plotting

### DIFF
--- a/plot_likert/plot_likert.py
+++ b/plot_likert/plot_likert.py
@@ -102,7 +102,7 @@ def plot_counts(
         xlabels = ["" if label > total_max else label for label in xlabels]
 
     if plot_percentage:
-        xlabels = [str(label) + "%" for label in xlabels if label != ""]
+        xlabels = [str(label) + "%" if label != "" else "" for label in xlabels]
 
     ax.set_xticks(xvalues)
     ax.set_xticklabels(xlabels)


### PR DESCRIPTION
Fix a bug in percentage plotting where, if a label has been hidden by `HIDE_EXCESSIVE_TICK_LABELS`, the `xlabels` array will end up resized to be smaller than the `xvalues` array. 